### PR TITLE
When using ACCUMULO_REPO, build with the appropriate Hadoop profile.

### DIFF
--- a/bin/impl/fetch.sh
+++ b/bin/impl/fetch.sh
@@ -59,10 +59,14 @@ function fetch_accumulo() {
   fi
 
   if [[ -n "$ACCUMULO_REPO" ]]; then
+    declare -a maven_args=(-DskipTests -DskipFormat)
+    if [[ "${HADOOP_VERSION}" = 3.* ]]; then
+      maven_args=("${maven_args[@]}" '-Dhadoop.profile=3')
+    fi
     rm -f "$DOWNLOADS/$ACCUMULO_TARBALL"
     pushd .
     cd "$ACCUMULO_REPO"
-    mvn clean package -DskipTests -DskipFormat
+    mvn clean package "${maven_args[@]}"
     accumulo_built_tarball=$ACCUMULO_REPO/assemble/target/$ACCUMULO_TARBALL
     if [[ ! -f "$accumulo_built_tarball" ]]; then
       echo


### PR DESCRIPTION
* when HADOOP_VERSION is 3.y.z, build Accumulo with hadoop.profile=3
* otherwise don't specify a hadoop.profile