### PR TITLE
Added instruction in the docs/centos7.md file  to make the authorized…

### DIFF
--- a/docs/centos7.md
+++ b/docs/centos7.md
@@ -10,6 +10,7 @@ sudo yum group install "Development Tools"
 ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa
 ssh-keyscan -H localhost >> ~/.ssh/known_hosts
 cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+chmod 0600 ~/.ssh/authorized_keys
 
 #add java home to your env by appending this line to ~/.bashrc
 export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk


### PR DESCRIPTION
Modify authorized_keys file to  read/write for user so ssh to localhost will work. It is set 664 by default with the instructions we give.  This will cause ssh localhost to  prompt for passphase.  If you don't check the ssh setup setup after running the commands in centos.md and go right to the Quickstart commands ssh won't work. The command uno setup accumulo will let you think everything went well but it did not.