### PR TITLE
Made scripts print info about failing commands

### DIFF
--- a/bin/impl/install/accumulo.sh
+++ b/bin/impl/install/accumulo.sh
@@ -21,6 +21,7 @@ pkill -f accumulo.start
 
 # stop if any command fails
 set -e
+trap 'echo "[ERROR] Error occurred at $BASH_SOURCE:$LINENO command: $BASH_COMMAND"' ERR
 
 if [[ -z "$ACCUMULO_REPO" ]]; then
   verify_exist_hash "$ACCUMULO_TARBALL" "$ACCUMULO_HASH"

--- a/bin/impl/install/fluo-yarn.sh
+++ b/bin/impl/install/fluo-yarn.sh
@@ -19,6 +19,7 @@ source "$UNO_HOME"/bin/impl/util.sh
 
 # stop if any command fails
 set -e
+trap 'echo "[ERROR] Error occurred at $BASH_SOURCE:$LINENO command: $BASH_COMMAND"' ERR
 
 if [[ -z "$FLUO_YARN_REPO" ]]; then
   verify_exist_hash "$FLUO_YARN_TARBALL" "$FLUO_YARN_HASH"
@@ -32,9 +33,11 @@ fi
 print_to_console "Setting up Apache Fluo YARN launcher at $FLUO_YARN_HOME"
 # Don't stop if pkills fail
 set +e
+trap - ERR
 pkill -f "fluo\.yarn"
 pkill -f twill.launcher
 set -e
+trap 'echo "[ERROR] Error occurred at $BASH_SOURCE:$LINENO command: $BASH_COMMAND"' ERR
 
 rm -rf "$INSTALL"/fluo-yarn*
 

--- a/bin/impl/install/fluo.sh
+++ b/bin/impl/install/fluo.sh
@@ -19,6 +19,7 @@ source "$UNO_HOME"/bin/impl/util.sh
 
 # stop if any command fails
 set -e
+trap 'echo "[ERROR] Error occurred at $BASH_SOURCE:$LINENO command: $BASH_COMMAND"' ERR
 
 if [[ -z "$FLUO_REPO" ]]; then
   verify_exist_hash "$FLUO_TARBALL" "$FLUO_HASH"
@@ -32,10 +33,12 @@ if [[ -f "$DOWNLOADS/$FLUO_TARBALL" ]]; then
   print_to_console "Setting up Apache Fluo at $FLUO_HOME"
   # Don't stop if pkills fail
   set +e
+  trap - ERR
   pkill -f fluo.yarn
   pkill -f MiniFluo
   pkill -f twill.launcher
   set -e
+  trap 'echo "[ERROR] Error occurred at $BASH_SOURCE:$LINENO command: $BASH_COMMAND"' ERR
 
   rm -rf "$INSTALL"/fluo-[0-9]*
 

--- a/bin/impl/install/hadoop.sh
+++ b/bin/impl/install/hadoop.sh
@@ -22,6 +22,7 @@ pkill -f hadoop.yarn
 
 # stop if any command fails
 set -e
+trap 'echo "[ERROR] Error occurred at $BASH_SOURCE:$LINENO command: $BASH_COMMAND"' ERR
 
 verify_exist_hash "$HADOOP_TARBALL" "$HADOOP_HASH"
 

--- a/bin/impl/install/zookeeper.sh
+++ b/bin/impl/install/zookeeper.sh
@@ -21,6 +21,7 @@ pkill -f QuorumPeerMain
 
 # stop if any command fails
 set -e
+trap 'echo "[ERROR] Error occurred at $BASH_SOURCE:$LINENO command: $BASH_COMMAND"' ERR
 
 verify_exist_hash "$ZOOKEEPER_TARBALL" "$ZOOKEEPER_HASH"
 

--- a/bin/impl/run/accumulo.sh
+++ b/bin/impl/run/accumulo.sh
@@ -21,6 +21,7 @@ pkill -f accumulo.start
 
 # stop if any command fails
 set -e
+trap 'echo "[ERROR] Error occurred at $BASH_SOURCE:$LINENO command: $BASH_COMMAND"' ERR
 
 if [[ $1 != "--no-deps" ]]; then
   run_component hadoop

--- a/bin/impl/run/fluo-yarn.sh
+++ b/bin/impl/run/fluo-yarn.sh
@@ -19,6 +19,7 @@ source "$UNO_HOME"/bin/impl/util.sh
 
 # stop if any command fails
 set -e
+trap 'echo "[ERROR] Error occurred at $BASH_SOURCE:$LINENO command: $BASH_COMMAND"' ERR
 
 if [[ $1 != "--no-deps" ]]; then
   run_component fluo

--- a/bin/impl/run/fluo.sh
+++ b/bin/impl/run/fluo.sh
@@ -23,6 +23,7 @@ pkill -f twill.launcher
 
 # stop if any command fails
 set -e
+trap 'echo "[ERROR] Error occurred at $BASH_SOURCE:$LINENO command: $BASH_COMMAND"' ERR
 
 if [[ $2 != "--no-deps" ]]; then
   run_component accumulo

--- a/bin/impl/run/hadoop.sh
+++ b/bin/impl/run/hadoop.sh
@@ -22,6 +22,7 @@ pkill -f hadoop.yarn
 
 # stop if any command fails
 set -e
+trap 'echo "[ERROR] Error occurred at $BASH_SOURCE:$LINENO command: $BASH_COMMAND"' ERR
 
 "$HADOOP_HOME"/bin/hdfs namenode -format
 "$HADOOP_HOME"/sbin/start-dfs.sh

--- a/bin/impl/run/zookeeper.sh
+++ b/bin/impl/run/zookeeper.sh
@@ -21,6 +21,7 @@ pkill -f QuorumPeerMain
 
 # stop if any command fails
 set -e
+trap 'echo "[ERROR] Error occurred at $BASH_SOURCE:$LINENO command: $BASH_COMMAND"' ERR
 
 rm -f "$ZOO_LOG_DIR"/*
 rm -rf "$DATA_DIR"/zookeeper


### PR DESCRIPTION
I tried to run Accumulo with JDK 11 using Uno and it failed.  The reason it failed is because the start-yarn.sh script was failing because of [HADOOP-15775](https://issues.apache.org/jira/browse/HADOOP-15775).  It took me a while to find where the Uno scripts were failing because when the yarn script failed, the uno script just stopped silently.

This change makes the scripts print something like the following when there is a failure.

```bash
cat uno/logs/setup/hadoop.out
Formatting using clusterid: CID-5e5b228b-78e0-4a45-ae29-da9aed51288b
Starting namenodes on [localhost]
Starting datanodes
Starting secondary namenodes [localhost]
Starting resourcemanager
Starting nodemanagers
[ERROR] Error occurred at uno/bin/impl/run/hadoop.sh:29 command: "$HADOOP_HOME"/sbin/start-yarn.sh
```
