### PR TITLE
Redirect message to prevent bash ERROR

### DIFF
--- a/conf/uno.conf
+++ b/conf/uno.conf
@@ -95,17 +95,17 @@ fi
 # consider submitting an issue or PR.
 
 if [[ "${HADOOP_VERSION}" = 1.* ]]; then
-   echo "ERROR from uno.conf : Hadoop 1.x is not supported"
+   echo "echo \"ERROR from uno.conf : Hadoop 1.x is not supported\""
    exit 1
 fi
 
 if [[ -z "$ACCUMULO_REPO" && "${ACCUMULO_VERSION}" = 1.* && ! "${HADOOP_VERSION}" = 2.* ]]; then
-   echo "ERROR from uno.conf : When using Accumulo 1.x, expect Hadoop 2.x not $HADOOP_VERSION"
+   echo "echo \"ERROR from uno.conf : When using Accumulo 1.x, expect Hadoop 2.x not $HADOOP_VERSION\""
    exit 1
 fi
 
 if [[ "${ACCUMULO_VERSION}" = 2.* && ! "${HADOOP_VERSION}" = 3.* ]]; then
-  echo "ERROR from uno.conf : When using Accumulo 2.x, expect Hadoop 3.x not $HADOOP_VERSION"
+  echo "echo \"ERROR from uno.conf : When using Accumulo 2.x, expect Hadoop 3.x not $HADOOP_VERSION\""
   exit 1
 fi
 

--- a/conf/uno.conf
+++ b/conf/uno.conf
@@ -95,17 +95,17 @@ fi
 # consider submitting an issue or PR.
 
 if [[ "${HADOOP_VERSION}" = 1.* ]]; then
-   echo "echo \"ERROR from uno.conf : Hadoop 1.x is not supported\""
+   echo "ERROR from uno.conf : Hadoop 1.x is not supported" 1>&2
    exit 1
 fi
 
 if [[ -z "$ACCUMULO_REPO" && "${ACCUMULO_VERSION}" = 1.* && ! "${HADOOP_VERSION}" = 2.* ]]; then
-   echo "echo \"ERROR from uno.conf : When using Accumulo 1.x, expect Hadoop 2.x not $HADOOP_VERSION\""
+   echo "ERROR from uno.conf : When using Accumulo 1.x, expect Hadoop 2.x not $HADOOP_VERSION" 1>&2
    exit 1
 fi
 
 if [[ "${ACCUMULO_VERSION}" = 2.* && ! "${HADOOP_VERSION}" = 3.* ]]; then
-  echo "echo \"ERROR from uno.conf : When using Accumulo 2.x, expect Hadoop 3.x not $HADOOP_VERSION\""
+  echo "ERROR from uno.conf : When using Accumulo 2.x, expect Hadoop 3.x not $HADOOP_VERSION" 1>&2
   exit 1
 fi
 


### PR DESCRIPTION
This is to prevent this error when running ```eval "$(./bin/uno env)" ```.
```bash
bash: ERROR: command not found
```

If a user runs the command directly ```./bin/uno env```, they will just see "echo" at the beginning of the message.  Which I think is a lot less confusing then the above bash error.