### PR TITLE
Update hadoop doc link to current

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,5 +200,5 @@ configuring, initializing, and starting your application.
 [ll]: https://github.com/apache/fluo-uno/blob/master/LICENSE
 [logo]: contrib/uno-logo.png
 [Muchos]: https://github.com/apache/fluo-muchos
-[ssh-docs]: https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/SingleCluster.html#Setup_passphraseless_ssh
+[ssh-docs]: https://hadoop.apache.org/docs/r3.2.1/hadoop-project-dist/hadoop-common/SingleCluster.html#Setup_passphraseless_ssh
 [Accumulo Proxy]: https://github.com/apache/accumulo-proxy

--- a/README.md
+++ b/README.md
@@ -200,5 +200,5 @@ configuring, initializing, and starting your application.
 [ll]: https://github.com/apache/fluo-uno/blob/master/LICENSE
 [logo]: contrib/uno-logo.png
 [Muchos]: https://github.com/apache/fluo-muchos
-[ssh-docs]: https://hadoop.apache.org/docs/r2.7.2/hadoop-project-dist/hadoop-common/SingleCluster.html#Setup_passphraseless_ssh
+[ssh-docs]: https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/SingleCluster.html#Setup_passphraseless_ssh
 [Accumulo Proxy]: https://github.com/apache/accumulo-proxy


### PR DESCRIPTION
The linked r2.7.2 section on passwordless ssh has outdated instructions using dsa.
Current docs show using rsa.