### PR TITLE
Update default zoo.cfg for ZooKeeper 3.5

### DIFF
--- a/conf/zookeeper/zoo.cfg
+++ b/conf/zookeeper/zoo.cfg
@@ -15,3 +15,7 @@ clientPort=2181
 # the maximum number of client connections.
 # increase this if you need to handle more clients
 maxClientCnxns=100
+# whitelist a few useful four-letter-word commands
+4lw.commands.whitelist=mntr,stat,ruok,wchs
+# disable the admin server listening on 8080 by default
+admin.enableServer=false


### PR DESCRIPTION
Add useful four-letter-word commands by default to ZooKeeper's
config file (zoo.cfg) and disable the built-in Admin Server,
which listens by default on port 8080.