### PR TITLE
Update uno.conf to properly handle ZooKeeper paths

### DIFF
--- a/conf/uno.conf
+++ b/conf/uno.conf
@@ -32,10 +32,12 @@ export DOWNLOADS=$UNO_HOME/downloads
 # Tarball file names
 export ACCUMULO_TARBALL=accumulo-$ACCUMULO_VERSION-bin.tar.gz
 export HADOOP_TARBALL=hadoop-"$HADOOP_VERSION".tar.gz
-export ZOOKEEPER_TARBALL=apache-zookeeper-"$ZOOKEEPER_VERSION"-bin.tar.gz
 export FLUO_TARBALL=fluo-$FLUO_VERSION-bin.tar.gz
 export FLUO_YARN_TARBALL=fluo-yarn-$FLUO_YARN_VERSION-bin.tar.gz
-
+export ZOOKEEPER_TARBALL=apache-zookeeper-"$ZOOKEEPER_VERSION"-bin.tar.gz
+if [[ "${ZOOKEEPER_VERSION}" = 3.[01234].* ]]; then
+    export ZOOKEEPER_TARBALL=zookeeper-"$ZOOKEEPER_VERSION".tar.gz
+fi
 # Building Accumulo
 #------------------
 # If set, 'uno fetch' will build (instead of downloading) an Accumulo tarball
@@ -118,6 +120,9 @@ export INSTALL=$UNO_HOME/install
 export DATA_DIR=$INSTALL/data
 # Home directories
 export ZOOKEEPER_HOME=$INSTALL/apache-zookeeper-$ZOOKEEPER_VERSION-bin
+if [[ "${ZOOKEEPER_VERSION}" = 3.[01234].* ]]; then
+  export ZOOKEEPER_HOME=$INSTALL/zookeeper-$ZOOKEEPER_VERSION
+fi
 export HADOOP_HOME=$INSTALL/hadoop-$HADOOP_VERSION
 export ACCUMULO_HOME=$INSTALL/accumulo-$ACCUMULO_VERSION
 export FLUO_HOME=$INSTALL/fluo-$FLUO_VERSION

--- a/conf/uno.conf
+++ b/conf/uno.conf
@@ -35,7 +35,7 @@ export HADOOP_TARBALL=hadoop-"$HADOOP_VERSION".tar.gz
 export FLUO_TARBALL=fluo-$FLUO_VERSION-bin.tar.gz
 export FLUO_YARN_TARBALL=fluo-yarn-$FLUO_YARN_VERSION-bin.tar.gz
 export ZOOKEEPER_TARBALL=apache-zookeeper-"$ZOOKEEPER_VERSION"-bin.tar.gz
-if [[ "${ZOOKEEPER_VERSION}" = 3.[01234].* ]]; then
+if [[ $ZOOKEEPER_VERSION =~ ^3[.][01234].*$ ]]; then
     export ZOOKEEPER_TARBALL=zookeeper-"$ZOOKEEPER_VERSION".tar.gz
 fi
 # Building Accumulo

--- a/conf/uno.conf
+++ b/conf/uno.conf
@@ -120,7 +120,7 @@ export INSTALL=$UNO_HOME/install
 export DATA_DIR=$INSTALL/data
 # Home directories
 export ZOOKEEPER_HOME=$INSTALL/apache-zookeeper-$ZOOKEEPER_VERSION-bin
-if [[ "${ZOOKEEPER_VERSION}" = 3.[01234].* ]]; then
+if [[ $ZOOKEEPER_VERSION =~ ^3[.][01234].*$ ]]; then
   export ZOOKEEPER_HOME=$INSTALL/zookeeper-$ZOOKEEPER_VERSION
 fi
 export HADOOP_HOME=$INSTALL/hadoop-$HADOOP_VERSION


### PR DESCRIPTION
Zookeeper changed naming and directory structure between versions 3.4 and 3.5. This update addresses changes in the ZOOKEEPER_TARBALL and ZOOKEEPER_HOME export definitions depending on version of ZK being used.