### PR TITLE
Allow use of Hadoop 3.x with Accumulo 1.10.x in uno.conf

### DIFF
--- a/conf/uno.conf
+++ b/conf/uno.conf
@@ -102,8 +102,8 @@ if [[ "${HADOOP_VERSION}" = 1.* ]]; then
    exit 1
 fi
 
-if [[ -z "$ACCUMULO_REPO" && "${ACCUMULO_VERSION}" = 1.* && ! "${HADOOP_VERSION}" = 2.* ]]; then
-   echo "ERROR from uno.conf : When using Accumulo 1.x, expect Hadoop 2.x not $HADOOP_VERSION" 1>&2
+if [[ -z "$ACCUMULO_REPO" && "${ACCUMULO_VERSION}" =~ ^1\.[[:digit:]]\.[[:digit:]]+$ && ! "${HADOOP_VERSION}" = 2.* ]]; then
+   echo "ERROR from uno.conf : When using Accumulo versions prior to 1.10.x, expect Hadoop 2.x not $HADOOP_VERSION" 1>&2
    exit 1
 fi
 

--- a/conf/uno.conf
+++ b/conf/uno.conf
@@ -96,13 +96,12 @@ fi
 # work with Hadoop 3.x.  The following sanity checks fail fast when versions
 # are incompatible.  If the checks cause a problem, comment them out and
 # consider submitting an issue or PR.
-
 if [[ "${HADOOP_VERSION}" = 1.* ]]; then
    echo "ERROR from uno.conf : Hadoop 1.x is not supported" 1>&2
    exit 1
 fi
 
-if [[ -z "$ACCUMULO_REPO" && "${ACCUMULO_VERSION}" =~ ^1\.[[:digit:]]\.[[:digit:]]+$ && ! "${HADOOP_VERSION}" = 2.* ]]; then
+if [[ -z $ACCUMULO_REPO && ${ACCUMULO_VERSION} =~ ^1[.][0-9][.][0-9]+$ && ! ${HADOOP_VERSION} = 2.* ]]; then
    echo "ERROR from uno.conf : When using Accumulo versions prior to 1.10.x, expect Hadoop 2.x not $HADOOP_VERSION" 1>&2
    exit 1
 fi


### PR DESCRIPTION
Update uno.conf version sanity check to allow Hadoop 3.x to be used with Accumulo versions 1.10 and greater.