### PR TITLE
Modify site file to allow multiple tservers for 1.10

### DIFF
--- a/conf/accumulo/1/accumulo-site.xml
+++ b/conf/accumulo/1/accumulo-site.xml
@@ -73,6 +73,19 @@
     <name>tserver.walog.max.size</name>
     <value>512M</value>
   </property>
+  <property>
+    <name>replication.receipt.service.port</name>
+    <value>0</value>
+  </property>
+  <property>
+    <name>tserver.port.search</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>tserver.port.client</name>
+    <value>11000</value>
+  </property>
+
 
   <property>
     <name>general.classpaths</name>


### PR DESCRIPTION
Properties that may be useful to others looking to run multiple tservers.  It took me some time to get these options to work out with the port numbering.  Basically, setting `replication.receipt.service.port=0` was the only way I could get it to work.