### PR TITLE
Update Accumulo.sh to handle new cluster.yaml file

### DIFF
--- a/bin/impl/install/accumulo.sh
+++ b/bin/impl/install/accumulo.sh
@@ -50,7 +50,9 @@ else
   accumulo_conf=$conf/accumulo.properties
   cp "$UNO_HOME"/conf/accumulo/2/* "$conf"
   "$ACCUMULO_HOME"/bin/accumulo-cluster create-config
-  $SED "s#localhost#$UNO_HOST#" "$conf/tservers"
+  if [[ -f "$conf/tservers" ]]; then
+    $SED "s#localhost#$UNO_HOST#" "$conf/tservers"
+  fi
   $SED "s#export HADOOP_HOME=[^ ]*#export HADOOP_HOME=$HADOOP_HOME#" "$conf"/accumulo-env.sh
   $SED "s#instance[.]name=#instance.name=$ACCUMULO_INSTANCE#" "$conf"/accumulo-client.properties
   $SED "s#instance[.]zookeepers=localhost:2181#instance.zookeepers=$UNO_HOST:2181#" "$conf"/accumulo-client.properties
@@ -63,11 +65,16 @@ else
   fi
 fi
 
-managers_file="$conf/managers"
-if [[ -f "$conf/masters" ]]; then
-  managers_file="$conf/masters"
+if [[ -f "$conf/cluster.yaml" ]]; then
+    $SED "s#localhost#$UNO_HOST#" "$conf/cluster.yaml"
+else
+  managers_file="$conf/managers"
+  if [[ -f "$conf/masters" ]]; then
+    managers_file="$conf/masters"
+  fi
+  $SED "s#localhost#$UNO_HOST#" "$managers_file" "$conf/monitor" "$conf/gc"
 fi
-$SED "s#localhost#$UNO_HOST#" "$managers_file" "$conf/monitor" "$conf/gc"
+
 $SED "s#export ZOOKEEPER_HOME=[^ ]*#export ZOOKEEPER_HOME=$ZOOKEEPER_HOME#" "$conf"/accumulo-env.sh
 $SED "s#export ACCUMULO_LOG_DIR=[^ ]*#export ACCUMULO_LOG_DIR=$ACCUMULO_LOG_DIR#" "$conf"/accumulo-env.sh
 if [[ $ACCUMULO_VERSION =~ ^1\..*$ ]]; then


### PR DESCRIPTION
Fixes #271. 

https://github.com/apache/accumulo/commit/03d76769366971ebacb575f7c5e6c962ddbea29c replaced the multiple service files with one cluster file. This change does the same `SED` command but against 'cluster.yaml' while still keep backward compatibility. I also confirmed the new external compaction services start up correctly.  