### PR TITLE
Remove 'component' from script executiion

### DIFF
--- a/bin/impl/run/fluo.sh
+++ b/bin/impl/run/fluo.sh
@@ -26,7 +26,7 @@ pkill -f twill.launcher
 set -e
 trap 'echo "[ERROR] Error occurred at $BASH_SOURCE:$LINENO command: $BASH_COMMAND"' ERR
 
-[[ $2 != '--no-deps' ]] && run_component accumulo
+[[ $1 != '--no-deps' ]] && run_component accumulo
 
 true
 # fluo.sh

--- a/bin/impl/util.sh
+++ b/bin/impl/util.sh
@@ -99,7 +99,7 @@ function run_component() {
   local logs; logs="$LOGS_DIR/setup"
   mkdir -p "$logs"
   shift
-  "$UNO_HOME/bin/impl/run/$component.sh" "$component" "$@" 1>"$logs/${component}.out" 2>"$logs/${component}.err" || return 1
+  "$UNO_HOME/bin/impl/run/$component.sh" "$@" 1>"$logs/${component}.out" 2>"$logs/${component}.err" || return 1
   case "$component" in
     accumulo|fluo) post_run_plugins ;;
     *) ;;


### PR DESCRIPTION
Fixes #275. 

Removes $component from https://github.com/apache/fluo-uno/blob/fc519d6b4a407575f3ce73ad28d33869a98021f9/bin/impl/util.sh#L102 so run/accumulo.sh properly sees $1 to be `--no-deps`. Also, fixes run/fluo.sh to look for `--no-deps` at $1 like the rest of the run components. 