### PR TITLE
Fix typo in performance profile in uno.conf

### DIFF
--- a/conf/uno.conf
+++ b/conf/uno.conf
@@ -175,7 +175,7 @@ export PROXY_HOME=$INSTALL/accumulo-proxy-"$PROXY_VERSION"
 
 # Performance Profiles
 # --------------------
-PERFORMANCE_PROFILE=8GX4
+PERFORMANCE_PROFILE=8GX2
 
 case "$PERFORMANCE_PROFILE" in
   8GX2)


### PR DESCRIPTION
in #283, I fixed some typos but also ended up introducing another one. This PR fixes the mistake I made in the performance profile name.