### PR TITLE
Add jshell cmd option to uno

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ and password `secret` (set in the `uno.conf` file). Therefore, the shell can be 
 accumulo shell -u root -p secret
 ```
 
+Starting with Accumulo 2.1, a Jshell session can also be used.
+```
+./bin/uno jshell
+```
+
 When you're all done testing out Accumulo you can clean up:
 ```
 ./bin/uno wipe

--- a/bin/impl/commands.sh
+++ b/bin/impl/commands.sh
@@ -279,6 +279,11 @@ function uno_ashell_main() {
   "$ACCUMULO_HOME"/bin/accumulo shell -u "$ACCUMULO_USER" -p "$ACCUMULO_PASSWORD" "$@"
 }
 
+function uno_jshell_main() {
+  check_dirs ACCUMULO_HOME || return 1
+  "$ACCUMULO_HOME"/bin/accumulo jshell "$@"
+}
+
 function uno_zk_main() {
   check_dirs ZOOKEEPER_HOME  || return 1
   "$ZOOKEEPER_HOME"/bin/zkCli.sh "$@"
@@ -327,6 +332,7 @@ Possible commands:
   status                 Check if Accumulo, Hadoop, or Zookeeper are running.
   kill                   Kills all processes
   ashell                 Runs the Accumulo shell
+  jshell                 Runs JShell with Accumulo properties
   zk                     Connects to ZooKeeper CLI
   env                    Prints out shell configuration for PATH and common environment variables.
                          Add '--paths' or '--vars' command to limit what is printed.

--- a/bin/uno
+++ b/bin/uno
@@ -37,7 +37,7 @@ source "$bin"/impl/load-env.sh "$uno_cmd"
 source "$UNO_HOME"/bin/impl/commands.sh
 
 case "$uno_cmd" in
-  ashell|env|fetch|install|kill|run|setup|start|status|stop|version|wipe|zk)
+  ashell|env|fetch|install|jshell|kill|run|setup|start|status|stop|version|wipe|zk)
     "uno_${uno_cmd}_main" "$@"
     ;;
   *)


### PR DESCRIPTION
Adds a cmd line option to uno for starting an Accumulo JShell session.