### PR TITLE
Auto-detect required bash, sed, and JDK versions

### DIFF
--- a/bin/impl/load-env.sh
+++ b/bin/impl/load-env.sh
@@ -122,10 +122,12 @@ fi
 hash shasum 2>/dev/null || { echo >&2 "shasum must be installed & on PATH. Aborting."; exit 1; }
 hash sed 2>/dev/null || { echo >&2 "sed must be installed & on PATH. Aborting."; exit 1; }
 
-if [[ $OSTYPE =~ ^darwin ]]; then
-  export SED="sed -i .bak"
-else
+if sed --version >/dev/null 2>&1; then
+  # GNU sed supports --version and -i without a backup suffix parameter
   export SED="sed -i"
+else
+  # BSD sed requires backup suffix parameter with -i
+  export SED="sed -i .bak"
 fi
 
 # load-env.sh

--- a/bin/impl/run/hadoop.sh
+++ b/bin/impl/run/hadoop.sh
@@ -27,9 +27,8 @@ trap 'echo "[ERROR] Error occurred at $BASH_SOURCE:$LINENO command: $BASH_COMMAN
 
 "$HADOOP_HOME"/bin/hdfs namenode -format
 "$HADOOP_HOME"/sbin/start-dfs.sh
-#
 # Yarn won't start on newer versions of Java
-jver=$("$JAVA_HOME"/bin/java -version 2>&1 | awk -F '"' '/version/ {print $2}' | awk -F '.' '{print $1}')
+jver=$("$JAVA_HOME"/bin/java -version 2>&1 | grep version | cut -f2 -d'"' | cut -f1 -d.)
 if [[ $jver -gt 11 ]]; then
   echo "Skipping yarn because it doesn't start on Java $jver"
 else

--- a/bin/impl/run/hadoop.sh
+++ b/bin/impl/run/hadoop.sh
@@ -27,7 +27,14 @@ trap 'echo "[ERROR] Error occurred at $BASH_SOURCE:$LINENO command: $BASH_COMMAN
 
 "$HADOOP_HOME"/bin/hdfs namenode -format
 "$HADOOP_HOME"/sbin/start-dfs.sh
-"$HADOOP_HOME"/sbin/start-yarn.sh
+#
+# Yarn won't start on newer versions of Java
+jver=$("$JAVA_HOME"/bin/java -version 2>&1 | awk -F '"' '/version/ {print $2}' | awk -F '.' '{print $1}')
+if [[ $jver -gt 11 ]]; then
+  echo "Skipping yarn because it doesn't start on Java $jver"
+else
+  "$HADOOP_HOME"/sbin/start-yarn.sh
+fi
 
 namenode_port=9870
 if [[ $HADOOP_VERSION =~ ^2\..*$ ]]; then

--- a/bin/impl/util.sh
+++ b/bin/impl/util.sh
@@ -111,7 +111,9 @@ function setup_component() {
 }
 
 function save_console_fd {
-  if [[ -z $UNO_CONSOLE_FD && ! $OSTYPE =~ ^darwin ]]; then
+  # this requires at least bash 4.1
+  local v=("${BASH_VERSINFO[@]}")
+  if [[ -z $UNO_CONSOLE_FD ]] && (( v[0]>4 || (v[0]==4 && v[1]>=1) )); then
     # Allocate an unused file descriptor and make it dup stdout
     # https://stackoverflow.com/a/41620630/7298689
     exec {UNO_CONSOLE_FD}>&1


### PR DESCRIPTION
* Only start Hadoop Yarn if using Java 11 or older, since it doesn't start using newer Java versions (definitely doesn't work with 17, but the change that broke it occurred somewhere between 11 and 17, and may depend on whether you're running it with experimental flags; I'm not certain of which change broke it, but this gets Uno working again for both 11 and 17)
* Stop making assumptions about sed version based on Darwin OS. The user could have installed GNU sed. Instead, check for GNU sed vs. BSD sed explicitly
* Stop making assumptions about bash version based on Darwin OS. The user could have installed a newer version of bash. Instead, check the bash version explicitly for the feature that requires 4.1 or later