### PR TITLE
Support accumulo's new default ssh behavior

### DIFF
--- a/bin/impl/commands.sh
+++ b/bin/impl/commands.sh
@@ -230,7 +230,7 @@ function uno_stop_main() {
       if pgrep -f accumulo\\.start >/dev/null; then
         if [[ $ACCUMULO_VERSION =~ ^1\..*$ ]]; then
           "$ACCUMULO_HOME"/bin/stop-all.sh
-        elif [[ $ACCUMULO_VERSION =~ ^2\.[0-1]\.[0-3]*$ ]]; then
+        elif [[ $ACCUMULO_VERSION =~ ^2\.[0-1]\.[0-3]$ ]]; then
           "$ACCUMULO_HOME"/bin/accumulo-cluster stop
         else
           "$ACCUMULO_HOME"/bin/accumulo-cluster stop --local

--- a/bin/impl/commands.sh
+++ b/bin/impl/commands.sh
@@ -168,7 +168,7 @@ function uno_start_main() {
       if [[ -z $tmp ]]; then
         if [[ $ACCUMULO_VERSION =~ ^1\..*$ ]]; then
           "$ACCUMULO_HOME"/bin/start-all.sh
-        elif [[ $ACCUMULO_VERSION =~ ^2\.[0-1]\.[0-3]*$ ]]; then
+        elif [[ $ACCUMULO_VERSION =~ ^2\.[0-1]\.[0-3]$ ]]; then
           "$ACCUMULO_HOME"/bin/accumulo-cluster start
         else
           "$ACCUMULO_HOME"/bin/accumulo-cluster start --local

--- a/bin/impl/commands.sh
+++ b/bin/impl/commands.sh
@@ -168,8 +168,10 @@ function uno_start_main() {
       if [[ -z $tmp ]]; then
         if [[ $ACCUMULO_VERSION =~ ^1\..*$ ]]; then
           "$ACCUMULO_HOME"/bin/start-all.sh
-        else
+        elif [[ $ACCUMULO_VERSION =~ ^2\.[0-1]\.[0-3]*$ ]]; then
           "$ACCUMULO_HOME"/bin/accumulo-cluster start
+        else
+          "$ACCUMULO_HOME"/bin/accumulo-cluster start --local
         fi
       else
         echo "Accumulo    already running at: $tmp"
@@ -228,8 +230,10 @@ function uno_stop_main() {
       if pgrep -f accumulo\\.start >/dev/null; then
         if [[ $ACCUMULO_VERSION =~ ^1\..*$ ]]; then
           "$ACCUMULO_HOME"/bin/stop-all.sh
-        else
+        elif [[ $ACCUMULO_VERSION =~ ^2\.[0-1]\.[0-3]*$ ]]; then
           "$ACCUMULO_HOME"/bin/accumulo-cluster stop
+        else
+          "$ACCUMULO_HOME"/bin/accumulo-cluster stop --local
         fi
       fi
 

--- a/bin/impl/run/accumulo.sh
+++ b/bin/impl/run/accumulo.sh
@@ -30,7 +30,7 @@ trap 'echo "[ERROR] Error occurred at $BASH_SOURCE:$LINENO command: $BASH_COMMAN
 "$ACCUMULO_HOME"/bin/accumulo init --clear-instance-name --instance-name "$ACCUMULO_INSTANCE" --password "$ACCUMULO_PASSWORD"
 if [[ $ACCUMULO_VERSION =~ ^1\..*$ ]]; then
   "$ACCUMULO_HOME"/bin/start-all.sh
-elif [[ $ACCUMULO_VERSION =~ ^2\.[0-1]\.[0-3]*$ ]]; then
+elif [[ $ACCUMULO_VERSION =~ ^2\.[0-1]\.[0-3]$ ]]; then
   "$ACCUMULO_HOME"/bin/accumulo-cluster start
 else
   "$ACCUMULO_HOME"/bin/accumulo-cluster start --local

--- a/bin/impl/run/accumulo.sh
+++ b/bin/impl/run/accumulo.sh
@@ -28,7 +28,13 @@ trap 'echo "[ERROR] Error occurred at $BASH_SOURCE:$LINENO command: $BASH_COMMAN
 
 "$HADOOP_HOME"/bin/hadoop fs -rm -r /accumulo 2>/dev/null || true
 "$ACCUMULO_HOME"/bin/accumulo init --clear-instance-name --instance-name "$ACCUMULO_INSTANCE" --password "$ACCUMULO_PASSWORD"
-"$ACCUMULO_HOME"/bin/accumulo-cluster start
+if [[ $ACCUMULO_VERSION =~ ^1\..*$ ]]; then
+  "$ACCUMULO_HOME"/bin/start-all.sh
+elif [[ $ACCUMULO_VERSION =~ ^2\.[0-1]\.[0-3]*$ ]]; then
+  "$ACCUMULO_HOME"/bin/accumulo-cluster start
+else
+  "$ACCUMULO_HOME"/bin/accumulo-cluster start --local
+fi
 
 print_to_console "Apache Accumulo $ACCUMULO_VERSION is running"
 print_to_console "    * Accumulo Monitor: http://localhost:9995/"


### PR DESCRIPTION
When using the accumulo-cluster script in 2.1.4-snapshot, all connections now default to being done via ssh vs a local command.

This change modifies the accumulo commands used to ensure that local start/stop commands are used so that uno's environment variables are used by accumulo-env.sh