### PR TITLE
Properly grab process names for use in No components running. display

### DIFF
--- a/bin/impl/commands.sh
+++ b/bin/impl/commands.sh
@@ -272,7 +272,7 @@ EOF
 }
 
 function uno_status_main() {
-  atmp="$(pgrep -f accumulo\\.start -a | awk '{pid = $1;for(i=1;i<=NF;i++)if($i=="org.apache.accumulo.start.Main")print $(i+1) "("pid")"}' | tr '\n' ' ')"
+  atmp="$(pgrep -f accumulo\\.start -a | awk '{pid = $1;for(i=1;i<=NF;i++)if($i=="org.apache.accumulo.start.Main"){name=$(i+1);if(name=="proc")name=$(i+2);if(name!="")print name "("pid")"}}' | tr '\n' ' ')"
   htmp="$(pgrep -f hadoop\\. -a | tr '.' ' ' | awk '{print $NF "(" $1 ")"}' | tr '\n' ' ')"
   ztmp="$(pgrep -f QuorumPeerMain | awk '{print "zoo(" $1 ")"}' | tr '\n' ' ')"
 


### PR DESCRIPTION
This allows `uno status` to properly display the name of the accumulo process. Without this change, everything appeared with the name `proc`