### PR TITLE
Support Accumulo 2.1.4 command compatibility

### DIFF
--- a/bin/impl/commands.sh
+++ b/bin/impl/commands.sh
@@ -168,7 +168,7 @@ function uno_start_main() {
       if [[ -z $tmp ]]; then
         if [[ $ACCUMULO_VERSION =~ ^1\..*$ ]]; then
           "$ACCUMULO_HOME"/bin/start-all.sh
-        elif [[ $ACCUMULO_VERSION =~ ^2\.[0-1]\.[0-3]$ ]]; then
+        elif [[ $ACCUMULO_VERSION =~ ^2\.[0-1]\..*$ ]]; then
           "$ACCUMULO_HOME"/bin/accumulo-cluster start
         else
           "$ACCUMULO_HOME"/bin/accumulo-cluster start --local
@@ -230,7 +230,7 @@ function uno_stop_main() {
       if pgrep -f accumulo\\.start >/dev/null; then
         if [[ $ACCUMULO_VERSION =~ ^1\..*$ ]]; then
           "$ACCUMULO_HOME"/bin/stop-all.sh
-        elif [[ $ACCUMULO_VERSION =~ ^2\.[0-1]\.[0-3]$ ]]; then
+        elif [[ $ACCUMULO_VERSION =~ ^2\.[0-1]\..*$ ]]; then
           "$ACCUMULO_HOME"/bin/accumulo-cluster stop
         else
           "$ACCUMULO_HOME"/bin/accumulo-cluster stop --local

--- a/bin/impl/install/accumulo.sh
+++ b/bin/impl/install/accumulo.sh
@@ -62,7 +62,7 @@ else
   if [[ -f "$conf/tservers" ]]; then
     $SED "s#localhost#$UNO_HOST#" "$conf/tservers"
   fi
-  $SED "s#export HADOOP_HOME=[^ ]*#export HADOOP_HOME=$HADOOP_HOME#" "$conf"/accumulo-env.sh
+  $SED "s#^\(export \)\?HADOOP_HOME=.*#export HADOOP_HOME=$HADOOP_HOME#" "$conf"/accumulo-env.sh
   $SED "s#instance[.]name=#instance.name=$ACCUMULO_INSTANCE#" "$conf"/accumulo-client.properties
   $SED "s#instance[.]zookeepers=localhost:2181#instance.zookeepers=$UNO_HOST:2181#" "$conf"/accumulo-client.properties
   $SED "s#auth[.]principal=#auth.principal=$ACCUMULO_USER#" "$conf"/accumulo-client.properties
@@ -75,8 +75,8 @@ fi
 
 $SED "s#localhost#$UNO_HOST#" "$conf/cluster.yaml"
 
-$SED "s#export ZOOKEEPER_HOME=[^ ]*#export ZOOKEEPER_HOME=$ZOOKEEPER_HOME#" "$conf"/accumulo-env.sh
-$SED "s#export ACCUMULO_LOG_DIR=[^ ]*#export ACCUMULO_LOG_DIR=$ACCUMULO_LOG_DIR#" "$conf"/accumulo-env.sh
+$SED "s#^\(export \)\?ZOOKEEPER_HOME=.*#export ZOOKEEPER_HOME=$ZOOKEEPER_HOME#" "$conf"/accumulo-env.sh
+$SED "s#^\(export \)\?ACCUMULO_LOG_DIR=.*#export ACCUMULO_LOG_DIR=$ACCUMULO_LOG_DIR#" "$conf"/accumulo-env.sh
 if [[ $ACCUMULO_VERSION =~ ^1\..*$ ]]; then
   $SED "s#ACCUMULO_TSERVER_OPTS=.*#ACCUMULO_TSERVER_OPTS=\"-Xmx$ACCUMULO_TSERV_MEM -Xms$ACCUMULO_TSERV_MEM\"#" "$conf"/accumulo-env.sh
 else

--- a/bin/impl/run/accumulo.sh
+++ b/bin/impl/run/accumulo.sh
@@ -30,7 +30,7 @@ trap 'echo "[ERROR] Error occurred at $BASH_SOURCE:$LINENO command: $BASH_COMMAN
 if [[ $ACCUMULO_VERSION =~ ^1\..*$ ]]; then
   print_to_console "Accumulo 1 is not supported; use an earlier uno or a newer accumulo"
   exit 1
-elif [[ $ACCUMULO_VERSION =~ ^2\.[0-1]\.[0-3]$ ]]; then
+elif [[ $ACCUMULO_VERSION =~ ^2\.[0-1]\..*$ ]]; then
   "$ACCUMULO_HOME"/bin/accumulo init --clear-instance-name --instance-name "$ACCUMULO_INSTANCE" --password "$ACCUMULO_PASSWORD"
   "$ACCUMULO_HOME"/bin/accumulo-cluster start
 else


### PR DESCRIPTION
Ensure all 2.0.x  and 2.1.x accumulo versions use the pre-4.0 command layout.

The regex that was changed here only matched through accumulo 2.1.3.

This seems better than bumping the regex to allow for up to 2.1.4 so now we dont have to bump it each time and it will allow for all compatible versions. 